### PR TITLE
Fix/logging console rewrite

### DIFF
--- a/src/logger/Logger.js
+++ b/src/logger/Logger.js
@@ -37,12 +37,12 @@ export default class Logger {
             console.error = function () {
                 let args = Array.prototype.slice.call(arguments);
                 // error.apply(this, args);
-                log_logger.info(...args);
+                error_logger.error(...args);
             };
             console.info = function () {
                 let args = Array.prototype.slice.call(arguments);
                 // info.apply(this, args);
-                error_logger.error(...args);
+                log_logger.info(...args);
             };
             console.debug = function () {
                 /*if (global.settings.debug.value) {*/

--- a/src/logger/Logger.js
+++ b/src/logger/Logger.js
@@ -51,8 +51,8 @@ export default class Logger {
                 debug_logger.debug(...args);
             };
 
-            console.custom = function (loggerName, level, message) {
-                const custom_logger = getLogger(loggerName);
+            console.custom = function (logger, level, message) {
+                const custom_logger = getLogger(logger);
                 if (typeof custom_logger[level] === "function") {
                     custom_logger[level](message);
                 } else {

--- a/src/logger/Logger.js
+++ b/src/logger/Logger.js
@@ -32,28 +32,32 @@ export default class Logger {
             console.log = function () {
                 let args = Array.prototype.slice.call(arguments);
                 // log.apply(this, args);
-                log_logger.log("info", args[0]);
+                log_logger.info(...args);
             };
             console.error = function () {
                 let args = Array.prototype.slice.call(arguments);
                 // error.apply(this, args);
-                error_logger.log("error", args[0]);
+                log_logger.info(...args);
             };
             console.info = function () {
                 let args = Array.prototype.slice.call(arguments);
                 // info.apply(this, args);
-                log_logger.log("info", args[0]);
+                error_logger.error(...args);
             };
             console.debug = function () {
                 /*if (global.settings.debug.value) {*/
                 let args = Array.prototype.slice.call(arguments);
                 // debug.apply(this, [args[1], args[2]]);
-                debug_logger.log("debug", args[0]);
+                debug_logger.debug(...args);
             };
 
-            console.custom = function (logger, level, message) {
-                const custom_logger = getLogger(logger);
-                custom_logger.log(level, message);
+            console.custom = function (loggerName, level, message) {
+                const custom_logger = getLogger(loggerName);
+                if (typeof custom_logger[level] === "function") {
+                    custom_logger[level](message);
+                } else {
+                    custom_logger.info(message);
+                }
             };
         })();
     }


### PR DESCRIPTION
Fix console method overrides to preserve call stack trace compatibility with log4js (enableCallStack: true)

- Redirected console.error to error logger (was incorrectly using log logger)
- Redirected console.info to log logger (was incorrectly using error logger)
- Preserved argument slicing for compatibility with older Node versions
- Ensured console.custom routes to the correct logger and level